### PR TITLE
feat: allow to specify the `bssid` for registering and connecting network

### DIFF
--- a/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/packages/wifi_iot/ios/Classes/SwiftWifiIotPlugin.swift
@@ -120,6 +120,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
     private func connect(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let sSSID = (call.arguments as? [String : AnyObject])?["ssid"] as! String
+        let _ = (call.arguments as? [String : AnyObject])?["bssid"] as? String? // not used
         let sPassword = (call.arguments as? [String : AnyObject])?["password"] as! String?
         let bJoinOnce = (call.arguments as? [String : AnyObject])?["join_once"] as! Bool?
         let sSecurity = (call.arguments as? [String : AnyObject])?["security"] as! String?

--- a/packages/wifi_iot/lib/wifi_iot.dart
+++ b/packages/wifi_iot/lib/wifi_iot.dart
@@ -265,8 +265,41 @@ class WiFiForIoTPlugin {
     }
   }
 
+  /// Connect to the requested AP Wi-Fi network.
+  ///
+  /// @param [ssid] The SSID of the network to connect to.
+  ///   In case multiple networks share the same SSID, which one is connected to
+  ///   is undefined. Use the optional [bssid] parameters if you want to specify
+  ///   the network.
+  ///
+  /// @param [bssid] The BSSID (unique id) of the network to connect to.
+  ///   This allows to specify exactly which network to connect to.
+  ///   To obtain the BSSID, use [loadWifiList] (Android only) or save the value
+  ///   from a previous connection.
+  ///   On Android, specifying the BSSID will also result in no system message
+  ///   requesting permission being shown to the user.
+  ///   Does nothing on iOS.
+  ///
+  /// @param [password] The password of the network. Should only be null in case
+  ///   [security] NetworkSecurity.NONE is used.
+  ///
+  /// @param [security] The security type of the network. [NetworkSecurity.NONE]
+  ///   means no password is required.
+  ///   On Android, from version 10 (Q) onward, [NetworkSecurity.WEP] is no
+  ///   longer supported.
+  ///
+  /// @param [joinOnce] If true, the network will be removed on exit.
+  ///
+  /// @param [withInternet] Whether the connected network has internet access.
+  ///   Android only.
+  ///
+  /// @param [isHidden] Whether the SSID is hidden (not broadcasted by the AP).
+  ///
+  /// @returns True in case the requested network could be connected to, false
+  ///   otherwise.
   static Future<bool> connect(
     String ssid, {
+    String? bssid,
     String? password,
     NetworkSecurity security = NetworkSecurity.NONE,
     bool joinOnce = true,
@@ -278,6 +311,7 @@ class WiFiForIoTPlugin {
     try {
       bResult = await _channel.invokeMethod('connect', {
         "ssid": ssid.toString(),
+        "bssid": bssid?.toString(),
         "password": password?.toString(),
         "join_once": joinOnce,
         "with_internet": withInternet,
@@ -292,6 +326,7 @@ class WiFiForIoTPlugin {
 
   static Future<bool> registerWifiNetwork(
     String ssid, {
+    String? bssid,
     String? password,
     NetworkSecurity security = NetworkSecurity.NONE,
     bool isHidden = false,
@@ -301,6 +336,7 @@ class WiFiForIoTPlugin {
     try {
       await _channel.invokeMethod('registerWifiNetwork', {
         "ssid": ssid.toString(),
+        "bssid": bssid?.toString(),
         "password": password?.toString(),
         "security": serializeNetworkSecurityMap[security],
         "is_hidden": isHidden,
@@ -312,7 +348,8 @@ class WiFiForIoTPlugin {
   }
 
   static Future<bool> findAndConnect(String ssid,
-      {String? password,
+      {String? bssid,
+      String? password,
       bool joinOnce = true,
       bool withInternet = false}) async {
     if (!await isEnabled()) {
@@ -329,6 +366,7 @@ class WiFiForIoTPlugin {
     try {
       bResult = await _channel.invokeMethod('findAndConnect', {
         "ssid": ssid.toString(),
+        "bssid": bssid?.toString(),
         "password": password?.toString(),
         "join_once": joinOnce,
         "with_internet": withInternet,


### PR DESCRIPTION
Based on the idea in https://github.com/florian-guillemard/WiFiFlutter/pull/158.  
However, we do not try to get the BSSID on connection, it has to be provided by the user.

On Android, the user is explicitly asked to connect only the first time. Further reconnection can be done with no user interaction. This also filters networks with the same SSID but a different BSSID.
On iOS, does nothing.

Tested on Android 12 and iOS 15.  
I do not have a device to test the deprecated path in Android.